### PR TITLE
Replace server pages with static pages

### DIFF
--- a/bsconfig.json
+++ b/bsconfig.json
@@ -5,7 +5,12 @@
     { "dir": "pages", "subdirs": true },
     { "dir": "utils", "subdirs": true }
   ],
-  "bs-dependencies": ["reason-react", "bs-fetch", "decco"],
+  "bs-dependencies": [
+    "reason-react",
+    "bs-fetch",
+    "decco",
+    "@ryyppy/rescript-promise"
+  ],
   "ppx-flags": ["decco/ppx"],
   "reason": { "react-jsx": 3 },
   "package-specs": {

--- a/components/Blog.res
+++ b/components/Blog.res
@@ -1,9 +1,9 @@
 let getStaticProps: Next.GetStaticProps.t<WordPress.response, 'params, 'previewData> = _ctx => {
-  open Js.Promise
-  WordPress.Api.fetchPosts()->then_(((data, error)) => {
+  open Promise
+  WordPress.Api.fetchPosts()->then(((data, error)) => {
     let props: WordPress.response = {error: error, data: data}
     resolve({"props": props})
-  }, _)
+  })
 }
 
 module PostExcerpt = {

--- a/components/Blog.res
+++ b/components/Blog.res
@@ -1,8 +1,4 @@
-let getServerSideProps: Next.GetServerSideProps.t<
-  WordPress.response,
-  'params,
-  'previewData,
-> = _ctx => {
+let getStaticProps: Next.GetStaticProps.t<WordPress.response, 'params, 'previewData> = _ctx => {
   open Js.Promise
   WordPress.Api.fetchPosts()->then_(((data, error)) => {
     let props: WordPress.response = {error: error, data: data}

--- a/components/Post.res
+++ b/components/Post.res
@@ -1,15 +1,26 @@
 type params = {slug: string}
 
-let getServerSideProps: Next.GetServerSideProps.t<
-  WordPress.response,
-  params,
-  'previewData,
-> = ctx => {
+let getStaticProps: Next.GetStaticProps.t<WordPress.response, params, 'previewData> = ctx => {
   let {params} = ctx
   open Js.Promise
   WordPress.Api.fetchPosts(~slug=params.slug, ())->then_(((data, error)) => {
     let props: WordPress.response = {error: error, data: data}
     resolve({"props": props})
+  }, _)
+}
+
+let getStaticPaths: Next.GetStaticPaths.t<params> = () => {
+  open Js.Promise
+  WordPress.Api.fetchPosts()->then_(((data, _error)) => {
+    let paths = Array.map(post => {
+      let path: Next.GetStaticPaths.path<params> = {params: {slug: post.slug}}
+      path
+    }, data)
+    let return: Next.GetStaticPaths.return<params> = {
+      paths: paths,
+      fallback: true,
+    }
+    resolve(return)
   }, _)
 }
 

--- a/components/Post.res
+++ b/components/Post.res
@@ -12,10 +12,13 @@ let getStaticProps: Next.GetStaticProps.t<WordPress.response, params, 'previewDa
 let getStaticPaths: Next.GetStaticPaths.t<params> = () => {
   open Js.Promise
   WordPress.Api.fetchPosts()->then_(((data, _error)) => {
-    let paths = Array.map(post => {
-      let path: Next.GetStaticPaths.path<params> = {params: {slug: post.slug}}
-      path
-    }, data)
+    let paths = switch data->Js.Nullable.toOption {
+    | Some(posts) => Array.map(post => {
+        let path: Next.GetStaticPaths.path<params> = {params: {slug: post.slug}}
+        path
+      }, posts)
+    | None => []
+    }
     let return: Next.GetStaticPaths.return<params> = {
       paths: paths,
       fallback: true,

--- a/components/Post.res
+++ b/components/Post.res
@@ -10,13 +10,13 @@ let getStaticProps: Next.GetStaticProps.t<WordPress.response, params, 'previewDa
 }
 
 let getStaticPaths: Next.GetStaticPaths.t<params> = () => {
-  open Js.Promise
-  WordPress.Api.fetchPosts()->then_(((data, _error)) => {
+  open Promise
+  WordPress.Api.fetchPosts()->then(((data, _error)) => {
     let paths = switch data->Js.Nullable.toOption {
-    | Some(posts) => Array.map(post => {
+    | Some(posts) => Belt.Array.map(posts, post => {
         let path: Next.GetStaticPaths.path<params> = {params: {slug: post.slug}}
         path
-      }, posts)
+      })
     | None => []
     }
     let return: Next.GetStaticPaths.return<params> = {
@@ -24,7 +24,7 @@ let getStaticPaths: Next.GetStaticPaths.t<params> = () => {
       fallback: true,
     }
     resolve(return)
-  }, _)
+  })
 }
 
 let default = (props: WordPress.response): React.element => {
@@ -33,8 +33,8 @@ let default = (props: WordPress.response): React.element => {
     {switch (data->Js.Nullable.toOption, error->Js.Nullable.toOption) {
     | (_, Some({message})) => <Paragraph> {message->React.string} </Paragraph>
     | (None, None) => <Paragraph> {"Loading"->React.string} </Paragraph>
-    | (Some(posts), _) when Array.length(posts) > 0 => {
-        let {title, featuredImage, date, content} = posts->Array.get(0)
+    | (Some(posts), _) when Belt.Array.length(posts) > 0 => {
+        let {title, featuredImage, date, content} = posts[0]
         let filteredTitle = Js.String.replaceByRe(%re("/&nbsp;/g"), " ", title.rendered)
         <>
           <SEO title=filteredTitle />

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "start": "next start"
   },
   "dependencies": {
+    "@ryyppy/rescript-promise": "^2.1.0",
     "@tailwindcss/aspect-ratio": "^0.2.1",
     "autoprefixer": "^10.0.4",
     "bs-fetch": "^0.6.2",

--- a/pages/blog/[slug].js
+++ b/pages/blog/[slug].js
@@ -1,6 +1,6 @@
 import PostRes from "../../components/Post.bs";
 
-export { getServerSideProps } from "../../components/Post.bs";
+export { getStaticProps, getStaticPaths } from "../../components/Post.bs";
 
 export default function Post(props) {
   return <PostRes {...props} />;

--- a/pages/blog/index.js
+++ b/pages/blog/index.js
@@ -1,6 +1,6 @@
 import BlogRes from "../../components/Blog.bs";
 
-export { getServerSideProps } from "../../components/Blog.bs";
+export { getStaticProps } from "../../components/Blog.bs";
 
 export default function Blog(props) {
   return <BlogRes {...props} />;

--- a/utils/Next.res
+++ b/utils/Next.res
@@ -26,6 +26,34 @@ module GetServerSideProps = {
   }>
 }
 
+module GetStaticProps = {
+  // See: https://github.com/zeit/next.js/blob/canary/packages/next/types/index.d.ts
+  type context<'props, 'params, 'previewData> = {
+    params: 'params,
+    preview: option<bool>, // preview is true if the page is in the preview mode and undefined otherwise.
+    previewData: Js.Nullable.t<'previewData>,
+  }
+
+  // The definition of a getStaticProps function
+  type t<'props, 'params, 'previewData> = context<'props, 'params, 'previewData> => Js.Promise.t<{
+    "props": 'props,
+  }>
+}
+
+module GetStaticPaths = {
+  // 'params: dynamic route params used in dynamic routing paths
+  // Example: pages/[id].js would result in a 'params = { id: string }
+  type path<'params> = {params: 'params}
+
+  type return<'params> = {
+    paths: array<path<'params>>,
+    fallback: bool,
+  }
+
+  // The definition of a getStaticPaths function
+  type t<'params> = unit => Js.Promise.t<return<'params>>
+}
+
 module Link = {
   @module("next/link") @react.component
   external make: (

--- a/utils/WordPress.res
+++ b/utils/WordPress.res
@@ -32,10 +32,10 @@ module Api = {
     | Some(slug) => postsUrl ++ "?slug=" ++ slug
     | _ => postsUrl
     }
-    open Js.Promise
-    Fetch.fetch(url)->then_(Fetch.Response.json, _)->then_(json => {
+    open Promise
+    Fetch.fetch(url)->then(Fetch.Response.json)->then(json => {
       let posts = switch Js.Json.classify(json) {
-      | Js.Json.JSONArray(array) => Array.map(decodePost, array)
+      | Js.Json.JSONArray(array) => Belt.Array.map(array, decodePost)
       | _ => []
       }
       let error = switch Js.Json.classify(json) {
@@ -43,7 +43,7 @@ module Api = {
       | _ => Js.Nullable.null
       }
       resolve((Js.Nullable.return(posts), error))
-    }, _)->catch(_error => {
+    })->catch(_error => {
       resolve((
         Js.Nullable.null,
         Js.Nullable.return({
@@ -52,6 +52,6 @@ module Api = {
           data: None,
         }),
       ))
-    }, _)
+    })
   }
 }

--- a/utils/WordPress.res
+++ b/utils/WordPress.res
@@ -25,8 +25,6 @@ module Api = {
 
   let postsUrl = "https://public-api.wordpress.com/wp/v2/sites/lifestewardshipllc.wordpress.com/posts"
 
-  type fetchPosts<'return, 'error> = (~slug: option<string>) => ('return, 'error)
-
   let fetchPosts = (~slug=?, ()) => {
     let url = switch slug {
     | Some(slug) => postsUrl ++ "?slug=" ++ slug

--- a/utils/WordPress.res
+++ b/utils/WordPress.res
@@ -25,6 +25,8 @@ module Api = {
 
   let postsUrl = "https://public-api.wordpress.com/wp/v2/sites/lifestewardshipllc.wordpress.com/posts"
 
+  type fetchPosts<'return, 'error> = (~slug: option<string>) => ('return, 'error)
+
   let fetchPosts = (~slug=?, ()) => {
     let url = switch slug {
     | Some(slug) => postsUrl ++ "?slug=" ++ slug

--- a/yarn.lock
+++ b/yarn.lock
@@ -1046,9 +1046,9 @@ camelcase@^6.0.0:
   integrity sha512-c7wVvbw3f37nuobQNtgsgG9POC9qMbNuMQmTCqZv23b6MIz0fcYpBiOlv9gEN/hdLdnZTDQhg6e9Dq5M1vKvfg==
 
 caniuse-lite@^1.0.30001093, caniuse-lite@^1.0.30001113, caniuse-lite@^1.0.30001154, caniuse-lite@^1.0.30001157, caniuse-lite@^1.0.30001161:
-  version "1.0.30001161"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001161.tgz#64f7ffe79ee780b8c92843ff34feb36cea4651e0"
-  integrity sha512-JharrCDxOqPLBULF9/SPa6yMcBRTjZARJ6sc3cuKrPfyIk64JN6kuMINWqA99Xc8uElMFcROliwtz0n9pYej+g==
+  version "1.0.30001249"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001249.tgz"
+  integrity sha512-vcX4U8lwVXPdqzPWi6cAJ3FnQaqXbBqy/GZseKNQzRj37J7qZdGcBtxq/QLFNLLlfsoXLUdHw8Iwenri86Tagw==
 
 chalk@2.4.2, chalk@^2.0.0, chalk@^2.4.1, chalk@^2.4.2:
   version "2.4.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -317,6 +317,11 @@
   resolved "https://registry.yarnpkg.com/@next/react-refresh-utils/-/react-refresh-utils-10.0.3.tgz#276bec60eae18768f96baf8a52f668f657f50ab4"
   integrity sha512-XtzzPX2R4+MIyu1waEQUo2tiNwWVEkmObA6pboRCDTPOs4Ri8ckaIE08lN5A5opyF6GVN+IEq/J8KQrgsePsZQ==
 
+"@ryyppy/rescript-promise@^2.1.0":
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/@ryyppy/rescript-promise/-/rescript-promise-2.1.0.tgz#a33861274c41360cfbe872cf489f3dcb8dd526e6"
+  integrity sha512-+dW6msBrj2Lr2hbEMX+HoWCvN89qVjl94RwbYWJgHQuj8jm/izdPC0YzxgpGoEFdeAEW2sOozoLcYHxT6o5WXQ==
+
 "@tailwindcss/aspect-ratio@^0.2.1":
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/@tailwindcss/aspect-ratio/-/aspect-ratio-0.2.1.tgz#a7ce776688b8218d9559a6918f0bccc58f0f16dd"


### PR DESCRIPTION
Leverage `getStaticProps` and `getStaticPaths` instead of the server
equivalents, in hope of producing a faster, more stable experience.
