### PR TITLE
Fix form field validation

### DIFF
--- a/pages/contact.res
+++ b/pages/contact.res
@@ -90,8 +90,8 @@ let default = () => {
     | (Some(form), false) => {
         let errors =
           form["elements"]
-          ->Js.Array.from
-          ->Belt.Array.keep(el => !el["checkValidity"]())
+          ->Js.Array2.from
+          ->Belt.Array.keep(el => !el["checkValidity"](.))
           ->Belt.Array.map(el => {
             {TextInput.subject: el["name"], message: el["dataset"]["errorMessage"]}
           })


### PR DESCRIPTION
Force uncurried call of `checkValidity` to avoid error. The change to
`Array2` is unrelated.
