### PR TITLE
Fix error error from unnecessary repeat ReCaptcha render

### DIFF
--- a/utils/ReCaptcha.res
+++ b/utils/ReCaptcha.res
@@ -53,7 +53,7 @@ let useReCaptcha = (~key, ~callback) => {
       ->Belt.Array.get(0)
       ->Belt.Option.getExn
       ->Document.appendChild(scriptTag)
-    | (Some(_), Some(_), "object") => onReCaptchaLoad()
+    | (None, Some(_), "object") => onReCaptchaLoad()
     | _ => ()
     }
 


### PR DESCRIPTION
If a ReCaptcha network error occurred, there was a subsequent ReCaptcha
re-render that would throw another error.
