### PR TITLE
Change WordPress.com URL

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -7,6 +7,6 @@ const withTM = require("next-transpile-modules")(
 module.exports = withTM({
   pageExtensions: ["js", "bs.js"],
   images: {
-    domains: ["lifestewardshipllc.files.wordpress.com"],
+    domains: ["lifestewardshipllc.files.wordpress.com", "i0.wp.com"],
   },
 });

--- a/utils/WordPress.res
+++ b/utils/WordPress.res
@@ -33,7 +33,7 @@ module Api = {
   external decodePost: Js.Json.t => post = "%identity"
   external decodeError: Js.Dict.t<Js.Json.t> => error = "%identity"
 
-  let postsUrl = "https://public-api.wordpress.com/wp/v2/sites/lifestewardshipllc.wordpress.com/posts"
+  let postsUrl = "https://public-api.wordpress.com/wp/v2/sites/lifestewardshipllc.wpcomstaging.com/posts"
   let publicStatus = "status=publish,private"
   let previewStatus = publicStatus ++ ",draft,pending,future"
 


### PR DESCRIPTION
Installing a third-party theme causes the WordPress.com URL to change.
